### PR TITLE
Master: Fix failing testcase

### DIFF
--- a/R/get_chemscorev1.6.71.R
+++ b/R/get_chemscorev1.6.71.R
@@ -82,7 +82,7 @@ do_something <- function(i,
       max_isp_count <- max_isp
 
       if (max_isp_count > 0 && isnum <= max_isp_count && bool_check > 0) {
-        isnum2 <- (round(put_isp_masses_curmz_data[isp_v, 1]) - round(as.numeric(mchemicaldata$MonoisotopicMass[m])))
+        isnum2 <- (round(put_isp_masses_curmz_data[isp_v, 1]) - round(as.numeric(as.character(mchemicaldata$MonoisotopicMass[m]))))
         isnum2 <- round(isnum2)
 
         isp_sign <- if (isnum2 <= 0) "-" else "+"

--- a/tests/testthat/test-multilevelannotationstep2.R
+++ b/tests/testthat/test-multilevelannotationstep2.R
@@ -49,6 +49,7 @@ patrick::with_parameters_test_that(
 
     keys <- c("mz", "time", "Name", "Adduct", "Formula", "chemical_ID", "cur_chem_score")
 
+    actual$MonoisotopicMass <- as.character(actual$MonoisotopicMass)
     actual <- dplyr::arrange_at(
       actual, keys
     )


### PR DESCRIPTION
Fix failing `qc_matrix` testcase:
+ `MonoisotopicMass` column is a **factor** datatype. Because of this, 
```
as.numeric(mchemicaldata$MonoisotopicMass[m])
```
returned a level (length) of the factor (integer) instead of the actual mass value. To convert **factors** to **numerical** you need to convert them to **strings** first. Quoting @xtrojak's comment, "this is fishy but necessary".
+ Adjusted `multilevelannotationstep2` to ensure that the `MonoisotopicMass` in the **actual** table is a string (as it is in **expected** data)
+ Also it appears that `qc_matrix` is the only test data where xMSannotator is able to find some isotopes (probably false positives). That's why the issue occurred only in this testcase.

Closes #49.