### PR TITLE
Fix tests after october branch merge

### DIFF
--- a/xmsannotator/R/get_confidence_stage4.R
+++ b/xmsannotator/R/get_confidence_stage4.R
@@ -51,11 +51,9 @@ get_confidence_stage4 <-function(curdata,
     cur_adducts_with_isotopes <- curdata$Adduct
     
     cur_adducts <-gsub(cur_adducts_with_isotopes, pattern = "(_\\[(\\+|\\-)[0-9]*\\])", replacement = "")
+
+    adduct_weights <- create_adduct_weights(adduct_weights)
     
-    if (is.na(adduct_weights)) {
-      adduct_weights <- data.frame(Adduct = c("M+H", "M-H"), Weight = c(1, 1))
-    }
-  
     adduct_monoisot <- data.frame(cbind("M", 1, 1, 0, "-", "S"))
     colnames(adduct_monoisot) <- colnames(adduct_table)
     adduct_table <- rbind(adduct_table, adduct_monoisot)

--- a/xmsannotator/R/get_confidence_stage4.R
+++ b/xmsannotator/R/get_confidence_stage4.R
@@ -69,7 +69,7 @@ get_confidence_stage4 <-function(curdata,
     }
     
     if (length(unique(curdata$Adduct)) < 2) {
-      if (curdata$score < 10 && length(which(cur_adducts %in% filter.by)) < 1) {
+      if (curdata$score[1] < 10 && length(which(cur_adducts %in% filter.by)) < 1) {
         chemscoremat_conf_levels <- "None"
       } else if (length(which(cur_adducts %in% filter.by)) > 0) {
         chemscoremat_conf_levels <- "Low"
@@ -142,9 +142,9 @@ get_confidence_stage4 <-function(curdata,
     module_names <- names(table_modules[which(table_modules > 0)])
     
     if (length(module_names) > 1) {
-      if (curdata$score < 10) {
+      if (curdata$score[1] < 10) {
         chemscoremat_conf_levels <- "None"
-      } else if (curdata$score > 10 && length(which(cur_adducts %in% filter.by)) > 0) {
+      } else if (curdata$score[1] > 10 && length(which(cur_adducts %in% filter.by)) > 0) {
         chemscoremat_conf_levels <- "Medium"
       }
     }
@@ -154,7 +154,7 @@ get_confidence_stage4 <-function(curdata,
         chemscoremat_conf_levels <- "Low"
       } else {
         # matches an M+H and score is greater than 10
-        if (curdata$score > 10 && length(which(cur_adducts %in% filter.by)) > 0) {
+        if (curdata$score[1] > 10 && length(which(cur_adducts %in% filter.by)) > 0) {
           chemscoremat_conf_levels <- "Medium"
         } else {
           chemscoremat_conf_levels <- "None"
@@ -282,13 +282,13 @@ get_confidence_stage4 <-function(curdata,
           chemscoremat_conf_levels <- "None"
         }
       } else {
-        if (curdata$score < 10) {
+        if (curdata$score[1] < 10) {
           if (length(which(cur_adducts %in% filter.by)) < 1) {
             chemscoremat_conf_levels <- "None"
           } else {
             chemscoremat_conf_levels <- "Low"
           }
-        } else if (curdata$score > 10 && length(which(cur_adducts %in% filter.by)) > 0) {
+        } else if (curdata$score[1] > 10 && length(which(cur_adducts %in% filter.by)) > 0) {
           chemscoremat_conf_levels <- "Medium"
         }
       }

--- a/xmsannotator/R/get_confidence_stage4.R
+++ b/xmsannotator/R/get_confidence_stage4.R
@@ -109,7 +109,7 @@ get_confidence_stage4 <-function(curdata,
       curdata$Module_RTclust <- module_clust
       
       if (length(which(adduct_weights[, 1] %in% cur_adducts)) > 0 && curdata$score[1] > 0.1) {
-        if (is.na(filter.by)) {
+        if (is.na(filter.by[1])) {
           good_mod <- curdata$Module_RTclust[which(curdata$Adduct %in% adduct_weights[, 1])]
         } else {
           good_mod <- curdata$Module_RTclust[which(curdata$Adduct %in% filter.by)]
@@ -120,7 +120,7 @@ get_confidence_stage4 <-function(curdata,
         curdata <- filter_clusters(curdata, names(cluster_table))
         delta_rt <- compute_delta_rt(curdata)
         
-        if (is.na(filter.by)) {
+        if (is.na(filter.by[1])) {
           if (curdata$score[1] > 0 && nrow(curdata) > 1 && length(unique(curdata$Adduct)) > 1 && delta_rt < max_diff_rt) {
             chemscoremat_conf_levels <- "High"
           } else {

--- a/xmsannotator/R/multilevelannotationstep3.R
+++ b/xmsannotator/R/multilevelannotationstep3.R
@@ -231,9 +231,7 @@ multilevelannotationstep3 <- function(chemCompMZ,
                                       max_diff_rt,
                                       pathwaycheckmode = "p",
                                       scorethresh = 0.1) {
-  if (is.na(adduct_weights)) {
-    adduct_weights <- data.frame(Adduct = c("M+H", "M-H"), Weight = c(1, 1))
-  }
+  adduct_weights <- create_adduct_weights(adduct_weights)
 
   column_names <- c(
     "score",

--- a/xmsannotator/R/multilevelannotationstep4.R
+++ b/xmsannotator/R/multilevelannotationstep4.R
@@ -13,7 +13,7 @@ compute_confidence_levels <- function(c,
     
     bool_check <- 1
 
-    if (!is.na(filter.by)) {
+    if (any(!is.na(filter.by))) {
         check_adduct <- which(curdata$Adduct %in% filter.by)
         if (length(check_adduct) <= 0) {
             bool_check <- 0

--- a/xmsannotator/R/multilevelannotationstep4.R
+++ b/xmsannotator/R/multilevelannotationstep4.R
@@ -13,7 +13,7 @@ compute_confidence_levels <- function(c,
     
     bool_check <- 1
 
-    if (any(!is.na(filter.by))) {
+    if (!is.na(filter.by[1])) {
         check_adduct <- which(curdata$Adduct %in% filter.by)
         if (length(check_adduct) <= 0) {
             bool_check <- 0
@@ -32,9 +32,9 @@ compute_confidence_levels <- function(c,
                     )
         if (!is.na(curdata[1, 1])) {
             Confidence <- as.numeric(as.character(curdata[, 1]))
-            if (Confidence < 2) {
+            if (Confidence[1] < 2) {
                 if (length(which(curdata$Adduct %in% adduct_weights[which(as.numeric(adduct_weights[, 2]) > 0), 1])) > 0) {
-                    if (curdata$score > 10) {
+                    if (curdata$score[1] > 10) {
                         mnum <- max(as.numeric(as.character(adduct_weights[which(adduct_weights[, 1] %in% curdata$Adduct), 2])))[1]
                         curdata <- curdata[which(curdata$Adduct %in% adduct_weights[which(as.numeric(as.character(adduct_weights[, 2])) >= mnum), 1]), ]
                         Confidence <- 2
@@ -44,7 +44,7 @@ compute_confidence_levels <- function(c,
         }
     } else {
         if (length(which(curdata$Adduct %in% adduct_weights[, 1])) > 0) {
-            if (curdata$score >= 10) {
+            if (curdata$score[1] >= 10) {
                 mnum <- max(as.numeric(as.character(adduct_weights[which(adduct_weights[, 1] %in% curdata$Adduct), 2])))[1]
                 if (length(which(curdata$Adduct %in% filter.by)) > 0) {
                     curdata <- curdata[which(curdata$Adduct %in% filter.by), ]
@@ -55,7 +55,7 @@ compute_confidence_levels <- function(c,
     }
 
     if (nrow(curdata) > 1) {
-        if (curdata$score < 10) {
+        if (curdata$score[1] < 10) {
             if (length(unique(curdata$Adduct)) < 2) {
                 Confidence <- 0
             }

--- a/xmsannotator/R/multilevelannotationstep4.R
+++ b/xmsannotator/R/multilevelannotationstep4.R
@@ -164,9 +164,7 @@ multilevelannotationstep4 <- function(outloc,
     data(adduct_table)
     adduct_table <- adduct_table[order(adduct_table$Adduct), ]
     
-    if (is.na(adduct_weights)) {
-        adduct_weights <- data.frame(Adduct = c("M+H", "M-H"), Weight = c(1, 1))
-    }
+    adduct_weights <- create_adduct_weights(adduct_weights)
 
     # assign confidence level
     chemscoremat_conf_levels <- lapply(

--- a/xmsannotator/R/multilevelannotationstep5.R
+++ b/xmsannotator/R/multilevelannotationstep5.R
@@ -1,5 +1,5 @@
 init_chemscoremat <- function(chemscoremat) {
-  if (is.na(chemscoremat)) {
+  if (any(is.na(chemscoremat))) {
     chemscoremat <- read.csv("Stage4.csv")
   }
   chemscoremat <- as.data.frame(chemscoremat)

--- a/xmsannotator/R/multilevelannotationstep5.R
+++ b/xmsannotator/R/multilevelannotationstep5.R
@@ -67,12 +67,7 @@ multilevelannotationstep5 <- function(outloc,
   setwd(outloc)
   curated_res <- init_chemscoremat(chemscoremat)
 
-  if (any(is.na(adduct_weights))) {
-    adduct_weights <- data.frame(
-      Adduct = c("M+H", "M-H"),
-      Weight = c(1, 1)
-    )
-  }
+  adduct_weights <- create_adduct_weights(adduct_weights)
 
   curated_res <- curated_res[order(curated_res$Confidence,
     curated_res$chemical_ID,

--- a/xmsannotator/R/utils.R
+++ b/xmsannotator/R/utils.R
@@ -128,3 +128,14 @@ load_boost_compounds_csv <- function (file) {
 save_parquet <- function(data, file) {
   invisible(arrow::write_parquet(data, file))
 }
+
+#' @export
+create_adduct_weights <- function(adduct_weights, weight = 1) {
+  if (any(is.na(adduct_weights))) {
+    adduct_weights <- data.frame(
+      Adduct = c("M+H", "M-H"),
+      Weight = c(weight, weight)
+    )
+  }
+  return(adduct_weights)
+}

--- a/xmsannotator/tests/remote-files/fetch_batch1_neg.txt
+++ b/xmsannotator/tests/remote-files/fetch_batch1_neg.txt
@@ -10,4 +10,4 @@ https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-xMSanno
 https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-xMSannotator/batch1_neg/global_cor.Rda
 https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-xMSannotator/batch1_neg/step1_results.Rda
 https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-xMSannotator/batch1_neg/tempobjects.Rda
-
+https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-xMSannotator/batch1_neg/global_cor_integ.Rda

--- a/xmsannotator/tests/remote-files/fetch_qc_matrix.txt
+++ b/xmsannotator/tests/remote-files/fetch_qc_matrix.txt
@@ -1,4 +1,3 @@
-
 https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-xMSannotator/qc_matrix/NumberOfCorrelationsPerFeature_cor0.7.csv
 https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-xMSannotator/qc_matrix/Stage1.csv
 https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-xMSannotator/qc_matrix/Stage2.csv
@@ -11,3 +10,4 @@ https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-xMSanno
 https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-xMSannotator/qc_matrix/global_cor.Rda
 https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-xMSannotator/qc_matrix/step1_results.Rda
 https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-xMSannotator/qc_matrix/tempobjects.Rda
+https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-xMSannotator/qc_matrix/global_cor_integ.Rda

--- a/xmsannotator/tests/remote-files/fetch_qc_matrix.txt
+++ b/xmsannotator/tests/remote-files/fetch_qc_matrix.txt
@@ -11,3 +11,4 @@ https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-xMSanno
 https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-xMSannotator/qc_matrix/step1_results.Rda
 https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-xMSannotator/qc_matrix/tempobjects.Rda
 https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-xMSannotator/qc_matrix/global_cor_integ.Rda
+https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-xMSannotator/qc_matrix/expected_chemscore.Rds

--- a/xmsannotator/tests/remote-files/fetch_qc_solvent.txt
+++ b/xmsannotator/tests/remote-files/fetch_qc_solvent.txt
@@ -10,5 +10,4 @@ https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-xMSanno
 https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-xMSannotator/qc_solvent/global_cor.Rda
 https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-xMSannotator/qc_solvent/step1_results.Rda
 https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-xMSannotator/qc_solvent/tempobjects.Rda
-
-
+https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-xMSannotator/qc_solvent/global_cor_integ.Rda

--- a/xmsannotator/tests/remote-files/fetch_qc_solvent.txt
+++ b/xmsannotator/tests/remote-files/fetch_qc_solvent.txt
@@ -11,3 +11,4 @@ https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-xMSanno
 https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-xMSannotator/qc_solvent/step1_results.Rda
 https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-xMSannotator/qc_solvent/tempobjects.Rda
 https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-xMSannotator/qc_solvent/global_cor_integ.Rda
+https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-xMSannotator/qc_solvent/expected_chemscore.Rds

--- a/xmsannotator/tests/remote-files/fetch_sourceforge.txt
+++ b/xmsannotator/tests/remote-files/fetch_sourceforge.txt
@@ -10,3 +10,4 @@ https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-xMSanno
 https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-xMSannotator/sourceforge/global_cor.Rda
 https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-xMSannotator/sourceforge/step1_results.Rda
 https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-xMSannotator/sourceforge/tempobjects.Rda
+https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-xMSannotator/sourceforge/global_cor_integ.Rda

--- a/xmsannotator/tests/remote-files/fetch_sourceforge.txt
+++ b/xmsannotator/tests/remote-files/fetch_sourceforge.txt
@@ -11,3 +11,4 @@ https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-xMSanno
 https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-xMSannotator/sourceforge/step1_results.Rda
 https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-xMSannotator/sourceforge/tempobjects.Rda
 https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-xMSannotator/sourceforge/global_cor_integ.Rda
+https://gitlab.ics.muni.cz/umsa/umsa-files/-/raw/master/testdata/recetox-xMSannotator/sourceforge/expected_chemscore.Rds

--- a/xmsannotator/tests/testthat/test-multilevelannotationstep3.R
+++ b/xmsannotator/tests/testthat/test-multilevelannotationstep3.R
@@ -21,7 +21,7 @@ patrick::with_parameters_test_that(
     # load and set arguments
     chemscoremat <- readRDS(file.path(testdata_dir, "chemscoremat.Rds"))
     load(file.path(testdata_dir, "chemCompMZ.Rda"))
-    adduct_weights <- data.frame(Adduct = c("M+H", "M-H"), Weight = c(5, 5))
+    adduct_weights <- create_adduct_weights(NA, 5)
     pathwaycheckmode <- "pm"
     
     setwd(outloc)

--- a/xmsannotator/tests/testthat/test_get_chemscore.R
+++ b/xmsannotator/tests/testthat/test_get_chemscore.R
@@ -1,33 +1,3 @@
-load_expected <- function(test_path) {
-  load(file = file.path(test_path, "step1_results.Rda"))
-  load(file = file.path(test_path, "global_cor.Rda"))
-  load(file = file.path(test_path, "tempobjects.Rda"))
-
-  outloc <- file.path(tempdir(), "get_chemscore", basename(test_path))
-
-  if(!dir.exists(outloc)) {
-      dir.create(outloc, recursive = TRUE)
-  }
-
-  expected <- multilevelannotationstep2(
-      outloc = outloc,
-      max_diff_rt = max.rt.diff,
-      mchemdata = mchemdata,
-      mass_defect_window = mass_defect_window,
-      corthresh = corthresh,
-      global_cor = global_cor,
-      adduct_weights = adduct_weights,
-      max_isp = max_isp,
-      MplusH.abundance.ratio.check = MplusH.abundance.ratio.check,
-      mass_defect_mode = mass_defect_mode,
-      chemids = chemids,
-      isop_res_md = isop_res_md,
-      filter.by = filter.by
-    )
-
-    return(expected)
-}
-
 patrick::with_parameters_test_that("Compute chemscore can be called isolated", {
 
     if (exists("skip_function") && is.function(skip_function)) {
@@ -49,7 +19,7 @@ patrick::with_parameters_test_that("Compute chemscore can be called isolated", {
       dir.create(outloc, recursive = TRUE)
     }
 
-    expected <- unique(load_expected(test_path))
+    expected <- readRDS(file.path(test_path, "expected_chemscore.Rds"))
 
     setwd(testthat_wd)
 

--- a/xmsannotator/tests/testthat/test_integration_utils.R
+++ b/xmsannotator/tests/testthat/test_integration_utils.R
@@ -24,7 +24,7 @@ patrick::with_parameters_test_that("Global cor adapter works", {
   testthat_wd <- getwd()
   test_path <- file.path(testthat_wd, "test-data")
 
-  load(file.path(test_path, test_identifier, "global_cor.Rda"))
+  load(file.path(test_path, test_identifier, "global_cor_integ.Rda"))
 
   peaks_filename <- file.path(test_path, paste0(test_identifier, ".parquet"))
   peak_table <- load_peak_table_parquet(peaks_filename)


### PR DESCRIPTION
The main reason why the tests were failing is the transition from R version `3` to version `4`, which changed behaviour of `if` conditions for multi-valued expressions. For example, the following code:

```R
if (c(1,2,3) < 3) {
   message('yes')
}
```
gives a warning for R below version `4`:
```R
Warning message:
In if (c(1, 2, 3) < 3) { :
  the condition has length > 1 and only the first element will be used
```
and an error for version above `4`:
```R
Error in if (c(1, 2, 3) < 3) { : the condition has length > 1
```

Also some of the test files were updated in https://gitlab.ics.muni.cz/umsa/umsa-files/-/merge_requests/30.

Close #99.