### PR TITLE
Disable code coverage for c++ code

### DIFF
--- a/.github/workflows/r-conda.yml
+++ b/.github/workflows/r-conda.yml
@@ -51,4 +51,5 @@ jobs:
       - name: Test coverage
         run: |
           conda activate recetox-xmsannotator-dev
+          options(covr.gcov="")
           Rscript -e "covr::codecov('xmsannotator', quiet = FALSE)"

--- a/.github/workflows/r-conda.yml
+++ b/.github/workflows/r-conda.yml
@@ -51,5 +51,4 @@ jobs:
       - name: Test coverage
         run: |
           conda activate recetox-xmsannotator-dev
-          options(covr.gcov="")
-          Rscript -e "covr::codecov('xmsannotator', quiet = FALSE)"
+          Rscript -e "options(covr.gcov=''); covr::codecov('xmsannotator', quiet = FALSE)"

--- a/conda/environment-dev.yaml
+++ b/conda/environment-dev.yaml
@@ -30,5 +30,4 @@ dependencies:
   - r-datacomparer >= 0.1.3
   - bioconductor-rdisop
   - r-stringi
-  - r-covr
-
+  - r-covr <= 3.5.1


### PR DESCRIPTION
Disable code coverage for c++ code.
This requires to pin `r-covr` package to version `3.5.1` because of [this issue](https://github.com/r-lib/covr/issues/516).

Credits: @zargham-ahmad 

Close #101.